### PR TITLE
Fix subprocess.CalledProcessError when building TorchServe GPU image in basic lab 5

### DIFF
--- a/Labs/BasicLabs/Lab5/Dockerfile.infer.gpu
+++ b/Labs/BasicLabs/Lab5/Dockerfile.infer.gpu
@@ -32,7 +32,7 @@ RUN apt-get update && \
     dpkg-dev \
     g++ \
     python3-dev \
-    openjdk-8-jdk-headless \
+    openjdk-11-jdk \
     curl \
     vim \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Environment
* OS: Ubuntu 18.04
* CUDA 11.0
* Python 3.6
## Command
`docker build --file Dockerfile.infer.gpu -t torchserve:0.1-gpu .`
## Error log
```bash
  Building wheel for torchserve (setup.py): started
  Building wheel for torchserve (setup.py): still running...
  Building wheel for torchserve (setup.py): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-8zsfe839/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-8zsfe839/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-gr9trt96

```
## Gradle output
```bash
FAILURE: Build failed with an exception.
  
  * What went wrong:
  Execution failed for task ':server:compileJava'.
  > Compilation failed; see the compiler error output for details.
  
  * Try:
  Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
  
  * Get more help at https://help.gradle.org

 BUILD FAILED in 1s
    9 actionable tasks: 8 executed, 1 up-to-date
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-8zsfe839/setup.py", line 164, in <module>
        license='Apache License Version 2.0'
      File "/usr/local/lib/python3.6/dist-packages/setuptools/__init__.py", line 153, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/usr/local/lib/python3.6/dist-packages/setuptools/command/install.py", line 61, in run
        return orig.install.run(self)
      File "/usr/lib/python3.6/distutils/command/install.py", line 589, in run
        self.run_command('build')
      File "/usr/lib/python3.6/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/usr/lib/python3.6/distutils/command/build.py", line 135, in run
        self.run_command(cmd_name)
      File "/usr/lib/python3.6/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/tmp/pip-req-build-8zsfe839/setup.py", line 103, in run
        self.run_command('build_frontend')
      File "/usr/lib/python3.6/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/tmp/pip-req-build-8zsfe839/setup.py", line 90, in run
        subprocess.check_call(build_frontend_command[platform.system()], shell=True)
      File "/usr/lib/python3.6/subprocess.py", line 311, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command 'frontend/gradlew -p frontend clean assemble' returned non-zero exit status 1.
```
## Solution
Change jdk version in GPU version of the Dockerfile.infer from **openjdk-8-jdk-headless** to **openjdk-11-jdk**, which resolve the problem.