### PR TITLE
Fix the bug between input type and weight type

### DIFF
--- a/Labs/BasicLabs/Lab1/mnist_tensorboard.py
+++ b/Labs/BasicLabs/Lab1/mnist_tensorboard.py
@@ -170,6 +170,7 @@ def main():
     #get some random traning images
     dataiter = iter(train_loader)
     images, labels = dataiter.next()
+    images = images.to(device)
 
     # show batch images
     grid = torchvision.utils.make_grid(images)


### PR DESCRIPTION
* Input type : torch.FloatTensor
* weight type : torch.cuda.FloatTensor
I fix the bug with the codes `images = images.to(device)`🙂